### PR TITLE
Disable the android SmartLock feature

### DIFF
--- a/app/src/main/java/com/infrontofthenet/restorater/SignInActivity.kt
+++ b/app/src/main/java/com/infrontofthenet/restorater/SignInActivity.kt
@@ -28,6 +28,7 @@ class SignInActivity : AppCompatActivity() {
         startActivityForResult(
             AuthUI.getInstance()
                 .createSignInIntentBuilder()
+                .setIsSmartLockEnabled(false)
                 .setAvailableProviders(providers)
                 .build(),
             RC_SIGN_IN)


### PR DESCRIPTION
Disable SmartLock when calling the FirebaseUI login activity. Could also be set based on the build version -> `!BuildConfig.DEBUG` for example.